### PR TITLE
Change child process spawn argument syntax to remove a leading space.

### DIFF
--- a/gulp/tasks/start.js
+++ b/gulp/tasks/start.js
@@ -55,7 +55,7 @@ gulp.task("start",function(cb){
     var time = (Number(argv.t) === argv.t && argv.t % 1 === 0) ? argv.t : 15;
 
     // FORK: also pass in the port for the server to use.
-    var serverHook = spawn('node', ['server.js', '-t ' + time, '--report-port=' + port],  {detached: true, stdio:'ignore'});
+    var serverHook = spawn('node', ['server.js', '--t=' + time, '--report-port=' + port],  {detached: true, stdio:'ignore'});
     serverHook.unref();
 
     // FORK: Write json string in file so we can include the port number.


### PR DESCRIPTION
"-t 0" is causing problems in later logic comparisons when argv.t is equal
to the string " 0".